### PR TITLE
add multi az support

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -21,6 +21,7 @@ resource "aws_elasticache_replication_group" "redis" {
   security_group_ids            = [aws_security_group.redis_security_group.id]
   apply_immediately             = var.apply_immediately
   tags                          = var.tags
+  multi_az_enabled              = var.multi_az_enabled
 }
 
 resource "aws_elasticache_parameter_group" "redis_parameter_group" {

--- a/variables.tf
+++ b/variables.tf
@@ -80,3 +80,8 @@ variable "tags" {
   type          = map(string)
   default       = null
 }
+
+variable "multi_az_enabled" {
+  description = "Redis cluster multi az support (redis_failover should be true)"
+  default       = false
+}


### PR DESCRIPTION
Multi AZ support default is false. 

See: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elasticache_replication_group#multi_az_enabled